### PR TITLE
Adjust jiracrawler to do all issues not just open

### DIFF
--- a/lib/jira.go
+++ b/lib/jira.go
@@ -165,7 +165,8 @@ func FetchAssignedIssuesWithProject(jiraURL, jiraUser, apikey string, projectID 
 	}
 	var allResults []AssignedIssuesResult
 	for _, user := range users {
-		jql := fmt.Sprintf("project=%s AND assignee=\"%s\" ORDER BY created DESC", projectID, user)
+		// Include all issues regardless of status (including resolved/closed)
+		jql := fmt.Sprintf("project=%s AND assignee=\"%s\" AND (resolution is empty OR resolution is not empty) ORDER BY created DESC", projectID, user)
 		issues, resp, err := client.Issue.Search(jql, nil)
 		if err != nil {
 			fmt.Printf("Error fetching issues for %s: %v\n", user, err)
@@ -215,7 +216,8 @@ func FetchUserIssuesInDateRange(jiraURL, jiraUser, apikey string, assignee strin
 	}
 
 	// JQL query to find issues assigned to the user that were updated in the date range
-	jql := fmt.Sprintf("assignee=\"%s\" AND updated >= \"%s\" AND updated <= \"%s\" ORDER BY updated DESC", assignee, startDate, endDate)
+	// Include all issues regardless of status (including resolved/closed)
+	jql := fmt.Sprintf("assignee=\"%s\" AND updated >= \"%s\" AND updated <= \"%s\" AND (resolution is empty OR resolution is not empty) ORDER BY updated DESC", assignee, startDate, endDate)
 
 	issues, resp, err := client.Issue.Search(jql, nil)
 	if err != nil {


### PR DESCRIPTION
This pull request modifies JQL queries in the `lib/jira.go` file to ensure that all issues, regardless of their resolution status (including resolved/closed issues), are included in the results. These changes enhance the comprehensiveness of issue fetching functions.

### Changes to JQL queries:

* `func FetchAssignedIssuesWithProject`:
  - Updated the JQL query to include all issues, regardless of their resolution status, by adding a condition `(resolution is empty OR resolution is not empty)`.

* `func FetchUserIssuesInDateRange`:
  - Modified the JQL query to include all issues, regardless of their resolution status, using the same condition `(resolution is empty OR resolution is not empty)`.