### PR TITLE
Update Go to 1.25.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/jiracrawler
 
-go 1.25.3
+go 1.25.4
 
 require (
 	github.com/andygrunwald/go-jira v1.17.0


### PR DESCRIPTION
This PR updates the Go version to 1.25.4.

Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3310