### PR TITLE
Restrict forks

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -40,23 +40,35 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       is-upstream: ${{ steps.check.outputs.is-upstream }}
+      should-run-tests: ${{ steps.check.outputs.should-run-tests }}
     steps:
       - name: Check if running on upstream repository
         id: check
         run: |
-          if [ "${{ github.repository }}" = "$UPSTREAM_REPO" ]; then
-            echo "is-upstream=true" >> $GITHUB_OUTPUT
-            echo "✅ Running on upstream repository: ${{ github.repository }}"
-          else
+          # Check if running on upstream repository
+          if [ "${{ github.repository }}" != "$UPSTREAM_REPO" ]; then
             echo "is-upstream=false" >> $GITHUB_OUTPUT
+            echo "should-run-tests=false" >> $GITHUB_OUTPUT
             echo "⚠️ Running on fork: ${{ github.repository }}, skipping integration tests"
+            exit 0
+          fi
+
+          echo "is-upstream=true" >> $GITHUB_OUTPUT
+
+          # Skip integration tests for Dependabot PRs (secrets not available)
+          if [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+            echo "should-run-tests=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Skipping integration tests for Dependabot PR (secrets not available)"
+          else
+            echo "should-run-tests=true" >> $GITHUB_OUTPUT
+            echo "✅ Running integration tests on upstream repository: ${{ github.repository }}"
           fi
 
   integration-tests:
     runs-on: ubuntu-latest
     needs: security-check
-    if: needs.security-check.outputs.is-upstream == 'true'
-    
+    if: needs.security-check.outputs.should-run-tests == 'true'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -71,7 +83,7 @@ jobs:
           echo "Repository: ${{ github.repository }}"
           echo "Ref: ${{ github.ref }}"
           echo "Event: ${{ github.event_name }}"
-          
+
       - name: Build binary
         run: make build
 
@@ -88,7 +100,7 @@ jobs:
             echo "  - JIRA_API_TOKEN"
             exit 1
           fi
-          
+
           echo "🔧 Configuring JIRA credentials..."
           ./jiracrawler config set --url "$JIRA_URL" --user "$JIRA_USER" --token "$JIRA_API_TOKEN"
 
@@ -100,7 +112,7 @@ jobs:
           echo "🧪 Running integration tests..."
           echo "Test user: $JIRACRAWLER_TEST_USER"
           echo "Test project: $JIRACRAWLER_TEST_PROJECT"
-          
+
           make integration-test
 
       - name: Cleanup credentials
@@ -113,24 +125,33 @@ jobs:
     runs-on: ubuntu-latest
     needs: [security-check, integration-tests]
     if: always()
-    
+
     steps:
       - name: Report results
         run: |
           echo "🔍 Integration Test Results"
           echo "=========================="
           echo "Event: ${{ github.event_name }}"
+          echo "Actor: ${{ github.actor }}"
           echo "Repository: ${{ github.repository }}"
           echo "Is Upstream: ${{ needs.security-check.outputs.is-upstream }}"
+          echo "Should Run Tests: ${{ needs.security-check.outputs.should-run-tests }}"
           echo "Test Result: ${{ needs.integration-tests.result }}"
           echo ""
-          
-          if [ "${{ needs.security-check.outputs.is-upstream }}" != "true" ]; then
-            echo "ℹ️ Integration tests skipped - running on fork"
-            echo "Integration tests require Jira credentials and only run on the upstream repository"
+
+          if [ "${{ needs.security-check.outputs.should-run-tests }}" != "true" ]; then
+            if [ "${{ needs.security-check.outputs.is-upstream }}" != "true" ]; then
+              echo "ℹ️ Integration tests skipped - running on fork"
+              echo "Integration tests require Jira credentials and only run on the upstream repository"
+            elif [ "${{ github.actor }}" = "dependabot[bot]" ]; then
+              echo "ℹ️ Integration tests skipped - Dependabot PR detected"
+              echo "Integration tests require secrets which are not available to Dependabot PRs for security reasons"
+            else
+              echo "ℹ️ Integration tests were skipped"
+            fi
             exit 0
           fi
-          
+
           if [ "${{ needs.integration-tests.result }}" = "success" ]; then
             echo "✅ Integration tests passed successfully"
           elif [ "${{ needs.integration-tests.result }}" = "failure" ]; then
@@ -141,4 +162,4 @@ jobs:
             echo "⚠️ Integration tests were skipped"
           else
             echo "❓ Integration tests had unexpected result: ${{ needs.integration-tests.result }}"
-          fi 
+          fi


### PR DESCRIPTION
This pull request updates the integration test workflow to improve security and clarity around when integration tests are executed. The main focus is to ensure integration tests only run on the upstream repository and not for Dependabot PRs, where required secrets are unavailable. The workflow also provides clearer output about why tests are skipped.

Workflow logic improvements:

* Added a new output variable `should-run-tests` in the `security-check` job to control whether integration tests should run, based on whether the workflow is running on the upstream repository and not triggered by Dependabot. The `integration-tests` job now uses this variable to decide if tests should execute.
* Updated the `security-check` step logic to explicitly handle forks and Dependabot PRs, skipping tests and providing clear messaging when these conditions are met.

Output and reporting enhancements:

* Enhanced the final reporting step to display the new `should-run-tests` value and provide detailed explanations in the logs when integration tests are skipped, distinguishing between forked repositories and Dependabot PRs.