### PR TITLE
Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,71 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+A CLI tool for querying, filtering, and reporting on Jira issues. Designed for Red Hat projects but works with any Jira instance. Supports fetching assigned issues, tracking user activity, and credential validation.
+
+## Common Commands
+
+### Build
+```bash
+make build
+```
+
+### Configure
+```bash
+./jiracrawler config set --user <email> --token <api-token> --url https://issues.redhat.com
+```
+
+### Run
+```bash
+# Get issues assigned to a user
+./jiracrawler issues --user <email> --project CNF
+
+# Validate credentials
+./jiracrawler config validate
+
+# Output as JSON/YAML
+./jiracrawler issues --format json
+```
+
+### Test
+```bash
+go test ./...
+```
+
+## Architecture
+
+- **`cmd/`** - CLI command implementations using Cobra
+- **`lib/`** - Jira API client library and utilities
+- **`scripts/`** - Helper scripts
+- **`main.go`** - Application entry point
+
+## Configuration
+
+Config file location: `.jiracrawler-config.yaml`
+```yaml
+jira_url: "https://issues.redhat.com"
+jira_user: "your-email@example.com"
+jira_token: "your-api-token"
+```
+
+## Features
+
+- Fetch issues assigned to users
+- Filter by project and status
+- User activity tracking by date range
+- JSON/YAML output formats
+- Credential validation
+
+## Requirements
+
+- Go 1.21+
+- Jira personal access token (PAT)
+
+## Code Style
+
+- Follow standard Go conventions
+- Use `go fmt` before committing
+- Run `golangci-lint` for linting


### PR DESCRIPTION
## Summary
- Adds CLAUDE.md file to provide guidance for Claude Code AI assistant
- Documents build commands, architecture, configuration, and features

## Test plan
- [x] File created and follows project conventions
- [ ] Review content for accuracy

## Related PRs
This is part of a batch update adding CLAUDE.md to all public repositories:

| Repository | PR |
|------------|-----|
| compliance-scripts | https://github.com/sebrandon1/compliance-scripts/pull/45 ✅ |
| OpenStack_Shortcuts | https://github.com/sebrandon1/OpenStack_Shortcuts/pull/1 |
| testapp | https://github.com/sebrandon1/testapp/pull/1 |
| yaml-to-readme | https://github.com/sebrandon1/yaml-to-readme/pull/70 |
| ztp-scripts | https://github.com/sebrandon1/ztp-scripts/pull/1 |
| mirrorbot | https://github.com/sebrandon1/mirrorbot/pull/17 |
| go-dci | https://github.com/sebrandon1/go-dci/pull/82 |
| ocp-doc-checker | https://github.com/sebrandon1/ocp-doc-checker/pull/38 |
| jiracrawler | https://github.com/sebrandon1/jiracrawler/pull/36 |
| go-quay | https://github.com/sebrandon1/go-quay/pull/67 |
| CryptoPrices | https://github.com/sebrandon1/CryptoPrices/pull/1 |
| cert-manager-scripts | https://github.com/sebrandon1/cert-manager-scripts/pull/10 |
| grab | https://github.com/sebrandon1/grab/pull/25 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)