### PR TITLE
Update Go to v1.25.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sebrandon1/jiracrawler
 
-go 1.25.5
+go 1.25.6
 
 require (
 	github.com/andygrunwald/go-jira v1.17.0


### PR DESCRIPTION
https://groups.google.com/g/golang-announce/c/Vd2tYVM8eUc/m/pQP7Bk0aCQAJ

## CVEs Addressed

- **CVE-2025-61728** (archive/zip): Super-linear file name indexing algorithm in ZIP archives can cause CPU exhaustion
- **CVE-2025-61726** (net/http): Request.ParseForm vulnerable to DoS with large number of key-value pairs
- **CVE-2025-61730** (crypto/tls): TLS 1.3 handshake information disclosure via message injection
- **CVE-2025-68119** (cmd/go): Arbitrary code execution via malicious VCS version strings
- **CVE-2025-68121** (crypto/tls): Config.Clone improperly copies session ticket keys allowing unauthorized session resumption
- **CVE-2025-61731** (net/url): URL parsing vulnerability

Related: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/3406