### PR TITLE
fix: remove pull_request_target trigger for security

### DIFF
--- a/.github/workflows/integration-nightly.yml
+++ b/.github/workflows/integration-nightly.yml
@@ -7,20 +7,7 @@ on:
   workflow_dispatch:
     # Allow manual triggering for testing
   pull_request:
-    # Run on pull requests to main (from same repo)
-    branches:
-      - main
-    paths:
-      - '**.go'
-      - 'go.mod'
-      - 'go.sum'
-      - 'Makefile'
-      - 'scripts/**'
-      - '.github/workflows/integration-nightly.yml'
-  pull_request_target:
-    # Run on PRs from forks (secrets are protected by security-check job)
-    # This allows fork contributors to see if their changes would pass integration tests
-    # Note: Integration tests will be skipped for forks (no secrets available)
+    # Run on pull requests to main
     branches:
       - main
     paths:


### PR DESCRIPTION
## Summary
- Removes the `pull_request_target` trigger from the integration-nightly workflow
- This addresses a security concern as `pull_request_target` can expose repository secrets to code from fork PRs

## Why this is safe
The `pull_request_target` trigger was redundant in this workflow because:
1. The `pull_request` trigger already handles PRs from the same repository
2. Fork PRs were being skipped anyway (no secrets available to them)
3. Manual runs can still be triggered via `workflow_dispatch`
4. Nightly runs continue via `schedule`

## Security Background
`pull_request_target` runs in the context of the base repository with access to secrets, which can be dangerous if the workflow checks out and executes code from the PR. While this workflow had some protections, removing the trigger entirely eliminates the risk.

## Test plan
- [ ] Verify the workflow still triggers on PRs to main from the same repo
- [ ] Verify manual workflow dispatch still works
- [ ] Verify scheduled nightly runs are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)